### PR TITLE
Fix GitHub Actions workflow syntax for paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,8 @@ on:
       - 'gradlew.bat'
       - '.github/workflows/**'
       - 'main'
-    paths-ignore:
-      - '**.md'
-      - '.gitignore'
+      - '!**.md'
+      - '!.gitignore'
 
 permissions:
   contents: write


### PR DESCRIPTION
Combined paths and paths-ignore in release.yml. In GitHub Actions you cannot use both paths and paths-ignore on the same event trigger, which caused parsing to fail.

---
*PR created automatically by Jules for task [8340457365118767323](https://jules.google.com/task/8340457365118767323) started by @pawanwashudev-official*