### PR TITLE
Fix filter list saving, enforce EncryptedSharedPreferences, and support importing encrypted Rclone configs

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -1603,6 +1603,9 @@ public class Rclone {
                     String line;
                     while ((line = stdOut.readLine()) != null || (line = stdErr.readLine()) != null) {
                         if (line.contains("could not parse line")) {
+                            if (line.contains("RCLONE_ENCRYPTED_v0")) {
+                                return true;
+                            }
                             return false;
                         }
                     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FilterEntryRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FilterEntryRecyclerViewAdapter.java
@@ -45,8 +45,12 @@ public class FilterEntryRecyclerViewAdapter extends RecyclerView.Adapter<FilterE
     public void onBindViewHolder(@NonNull final ViewHolder holder, final int position) {
         final FilterEntry selectedFilterEntry = filterEntries.get(position);
 
+        if (holder.textWatcher != null) {
+            holder.filterText.removeTextChangedListener(holder.textWatcher);
+        }
+
         holder.filterText.setText(selectedFilterEntry.filter);
-        holder.filterText.addTextChangedListener(new TextWatcher() {
+        holder.textWatcher = new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
             @Override
@@ -55,7 +59,8 @@ public class FilterEntryRecyclerViewAdapter extends RecyclerView.Adapter<FilterE
             }
             @Override
             public void afterTextChanged(Editable s) {}
-        });
+        };
+        holder.filterText.addTextChangedListener(holder.textWatcher);
 
 
 
@@ -97,6 +102,7 @@ public class FilterEntryRecyclerViewAdapter extends RecyclerView.Adapter<FilterE
         final Spinner filterTypeSpinner;
         final EditText filterText;
         final ImageButton fileOptions;
+        TextWatcher textWatcher;
 
         ViewHolder(View itemView) {
             super(itemView);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/util/SecurePreferencesHelper.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/util/SecurePreferencesHelper.kt
@@ -14,23 +14,30 @@ object SecurePreferencesHelper {
     fun getSecurePreferences(context: Context): SharedPreferences {
         if (securePrefs == null) {
             try {
-                val masterKey = MasterKey.Builder(context.applicationContext)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build()
-
-                securePrefs = EncryptedSharedPreferences.create(
-                    context.applicationContext,
-                    SECURE_PREFS_FILE,
-                    masterKey,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                )
+                securePrefs = createEncryptedSharedPreferences(context)
             } catch (e: Exception) {
-                FLog.e("SecurePreferencesHelper", "Failed to initialize EncryptedSharedPreferences, fallback to default", e)
-                securePrefs = context.applicationContext.getSharedPreferences(SECURE_PREFS_FILE, Context.MODE_PRIVATE)
+                FLog.e("SecurePreferencesHelper", "Failed to initialize EncryptedSharedPreferences, clearing and retrying", e)
+                // Delete the corrupted preferences file
+                context.applicationContext.deleteSharedPreferences(SECURE_PREFS_FILE)
+                // Retry creating EncryptedSharedPreferences. If it fails again, we let the exception bubble up.
+                securePrefs = createEncryptedSharedPreferences(context)
             }
         }
         return securePrefs!!
+    }
+
+    private fun createEncryptedSharedPreferences(context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context.applicationContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        return EncryptedSharedPreferences.create(
+            context.applicationContext,
+            SECURE_PREFS_FILE,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     fun putSecureString(context: Context, key: String, value: String?) {


### PR DESCRIPTION
- Fixed a bug in `FilterEntryRecyclerViewAdapter.java` where recycled ViewHolders had stale TextWatchers attached, causing incorrect items to be modified when scrolling. Handled by storing a reference to the watcher and removing it before calling `setText`.
- Modified `SecurePreferencesHelper.kt` to enforce the usage of EncryptedSharedPreferences. Removed the fallback to `Context.MODE_PRIVATE` plaintext preferences. When initialization fails (e.g. corrupted keystore), it deletes the corrupted file and retries.
- Modified `Rclone.java` `isValidConfig` to explicitly accept encrypted Rclone configuration files by checking the error output for `RCLONE_ENCRYPTED_v0`, which correctly allows the import functionality to proceed.

---
*PR created automatically by Jules for task [15538934058232201686](https://jules.google.com/task/15538934058232201686) started by @pawanwashudev-official*